### PR TITLE
feat: 사진 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 implementation 'org.flywaydb:flyway-core'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
     implementation 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
     implementation 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     // https://mvnrepository.com/artifact/org.hibernate.orm/hibernate-core

--- a/build.gradle
+++ b/build.gradle
@@ -19,24 +19,17 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    implementation 'org.springframework:spring-boot-starter-web'
-
-    // db
-    implementation 'org.springframework:spring-boot-starter-data-jpa'
-    implementation 'mysql:mysql-connector-java'
+implementation 'org.flywaydb:flyway-core'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.flywaydb:flyway-mysql'
+    implementation 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
-    // lombok
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
-
-    // JTS (Geometry)
-    implementation 'org.hibernate:hibernate-spatial:5.6.15.Final'
+    // https://mvnrepository.com/artifact/org.hibernate.orm/hibernate-core
+    implementation 'org.hibernate.orm:hibernate-core:6.6.34.Final'
+    // https://mvnrepository.com/artifact/org.locationtech.jts/jts-core
+    implementation 'org.locationtech.jts:jts-core:1.20.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,20 +19,22 @@ repositories {
 }
 
 dependencies {
-implementation 'org.flywaydb:flyway-core'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
-    implementation 'org.projectlombok:lombok'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    implementation 'com.mysql:mysql-connector-j'
 
     // https://mvnrepository.com/artifact/org.hibernate.orm/hibernate-core
-    implementation 'org.hibernate.orm:hibernate-core:6.6.34.Final'
+    implementation 'org.hibernate.orm:hibernate-spatial:6.6.34.Final'
+//    implementation 'org.hibernate.orm:hibernate-core:6.6.34.Final'
     // https://mvnrepository.com/artifact/org.locationtech.jts/jts-core
-    implementation 'org.locationtech.jts:jts-core:1.20.0'
+    implementation 'org.locationtech.jts:jts-core:1.19.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/kro/photoliner/common/model/BaseEntity.java
+++ b/src/main/java/kr/kro/photoliner/common/model/BaseEntity.java
@@ -14,9 +14,4 @@ public abstract class BaseEntity {
     @CreatedDate
     @Column(name = "created_at", columnDefinition = "TIMESTAMP", nullable = false, updatable = false)
     private LocalDateTime createdAt;
-
-    @NonNull
-    @CreatedDate
-    @Column(name = "updated_at", columnDefinition = "TIMESTAMP", nullable = false, updatable = true)
-    private LocalDateTime updatedAt;
 }

--- a/src/main/java/kr/kro/photoliner/common/model/BaseEntity.java
+++ b/src/main/java/kr/kro/photoliner/common/model/BaseEntity.java
@@ -17,6 +17,6 @@ public abstract class BaseEntity {
 
     @NonNull
     @CreatedDate
-    @Column(name = "createdAt", columnDefinition = "TIMESTAMP", nullable = false, updatable = true)
+    @Column(name = "updated_at", columnDefinition = "TIMESTAMP", nullable = false, updatable = true)
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/kr/kro/photoliner/common/util/datetime/DateTimes.java
+++ b/src/main/java/kr/kro/photoliner/common/util/datetime/DateTimes.java
@@ -1,0 +1,21 @@
+package kr.kro.photoliner.common.util.datetime;
+
+import java.time.LocalDateTime;
+
+public class DateTimes {
+
+    private DateTimes() {
+    }
+
+    public static boolean isBetween(LocalDateTime start, LocalDateTime end, LocalDateTime target) {
+        return isAfterEqualsTo(target, start) && isBeforeEqualsTo(target, end);
+    }
+
+    public static boolean isAfterEqualsTo(LocalDateTime date, LocalDateTime standardDate) {
+        return !date.isBefore(standardDate);
+    }
+
+    public static boolean isBeforeEqualsTo(LocalDateTime date, LocalDateTime standardDate) {
+        return !date.isAfter(standardDate);
+    }
+}

--- a/src/main/java/kr/kro/photoliner/common/util/datetime/DateTimes.java
+++ b/src/main/java/kr/kro/photoliner/common/util/datetime/DateTimes.java
@@ -1,21 +1,18 @@
 package kr.kro.photoliner.common.util.datetime;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 public class DateTimes {
 
-    private DateTimes() {
-    }
-
-    public static boolean isBetween(LocalDateTime start, LocalDateTime end, LocalDateTime target) {
+    public static boolean isBetween(LocalDate start, LocalDate end, LocalDate target) {
         return isAfterEqualsTo(target, start) && isBeforeEqualsTo(target, end);
     }
 
-    public static boolean isAfterEqualsTo(LocalDateTime date, LocalDateTime standardDate) {
+    public static boolean isAfterEqualsTo(LocalDate date, LocalDate standardDate) {
         return !date.isBefore(standardDate);
     }
 
-    public static boolean isBeforeEqualsTo(LocalDateTime date, LocalDateTime standardDate) {
+    public static boolean isBeforeEqualsTo(LocalDate date, LocalDate standardDate) {
         return !date.isAfter(standardDate);
     }
 }

--- a/src/main/java/kr/kro/photoliner/common/util/geometry/GeometryUtils.java
+++ b/src/main/java/kr/kro/photoliner/common/util/geometry/GeometryUtils.java
@@ -1,0 +1,5 @@
+package kr.kro.photoliner.common.util.geometry;
+
+public class GeometryUtils {
+
+}

--- a/src/main/java/kr/kro/photoliner/domain/photo/controller/PhotoController.java
+++ b/src/main/java/kr/kro/photoliner/domain/photo/controller/PhotoController.java
@@ -1,14 +1,41 @@
 package kr.kro.photoliner.domain.photo.controller;
 
+import kr.kro.photoliner.domain.photo.dto.response.PhotosResponse;
+import kr.kro.photoliner.domain.photo.dto.response.ViewportResponse;
 import kr.kro.photoliner.domain.photo.service.PhotoService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/photo")
 public class PhotoController {
+
     private final PhotoService photoService;
 
+    @GetMapping("/list")
+    public ResponseEntity<PhotosResponse> getPhotoList(
+            @RequestParam Long userId
+            ){
+        return ResponseEntity.ok(photoService.getPhotoList(userId));
+    }
+
+    @GetMapping("/viewport")
+    public ResponseEntity<ViewportResponse> getViewport(
+            @RequestParam Long userId,
+            @RequestParam LocalDateTime from,
+            @RequestParam LocalDateTime to,
+            @RequestParam double swLat,
+            @RequestParam double swLng,
+            @RequestParam double neLat,
+            @RequestParam double neLng
+            ){
+        return ResponseEntity.ok(photoService.getViewport(userId, from, to, swLat, swLng, neLat, neLng));
+    }
 }

--- a/src/main/java/kr/kro/photoliner/domain/photo/controller/PhotoController.java
+++ b/src/main/java/kr/kro/photoliner/domain/photo/controller/PhotoController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,8 +29,8 @@ public class PhotoController {
     @GetMapping("/viewport")
     public ResponseEntity<ViewportResponse> getViewport(
             @RequestParam Long userId,
-            @RequestParam LocalDateTime from,
-            @RequestParam LocalDateTime to,
+            @RequestParam LocalDate from,
+            @RequestParam LocalDate to,
             @RequestParam double swLat,
             @RequestParam double swLng,
             @RequestParam double neLat,

--- a/src/main/java/kr/kro/photoliner/domain/photo/dto/response/PhotosResponse.java
+++ b/src/main/java/kr/kro/photoliner/domain/photo/dto/response/PhotosResponse.java
@@ -1,0 +1,38 @@
+package kr.kro.photoliner.domain.photo.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import kr.kro.photoliner.domain.photo.model.Photo;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record PhotosResponse(
+        Integer count,
+        List<InnerPhotoResponse> photos
+) {
+    public static PhotosResponse from(List<Photo> photos){
+        return new PhotosResponse(
+                photos.size(),
+                photos.stream()
+                        .map(InnerPhotoResponse::from)
+                        .toList()
+        );
+    }
+
+    public record InnerPhotoResponse(
+            Long id,
+            String filePath,
+            LocalDateTime capturedDt,
+            Long userId
+    ){
+        public static InnerPhotoResponse from(Photo photo){
+            return new InnerPhotoResponse(
+                    photo.getId(),
+                    photo.getFilePath(),
+                    photo.getCapturedDt(),
+                    photo.getUser().getId());
+        }
+    }
+}

--- a/src/main/java/kr/kro/photoliner/domain/photo/dto/response/ViewportResponse.java
+++ b/src/main/java/kr/kro/photoliner/domain/photo/dto/response/ViewportResponse.java
@@ -1,0 +1,42 @@
+package kr.kro.photoliner.domain.photo.dto.response;
+
+import kr.kro.photoliner.common.util.datetime.DateTimes;
+import kr.kro.photoliner.domain.photo.model.Photo;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ViewportResponse(
+        PhotosResponse photos,
+        List<InnerPointResponse> points
+) {
+    public static ViewportResponse from(List<Photo> photos, LocalDateTime from, LocalDateTime to){
+        PhotosResponse photosResponse = PhotosResponse.from(
+                photos.stream()
+                        .filter(it-> DateTimes.isBetween(from, to, it.getCapturedDt()))
+                        .toList()
+        );
+
+        List<InnerPointResponse> points = photos.stream()
+                .filter(it->DateTimes.isBetween(from, to, it.getCapturedDt()))
+                .map(InnerPointResponse::from)
+                .toList();
+
+        return new ViewportResponse(photosResponse, points);
+    }
+
+    public record InnerPointResponse(
+            Long id,
+            double lat, // y
+            double lng // x
+    ){
+        public static InnerPointResponse from(Photo photo){
+            return new InnerPointResponse(
+                    photo.getId(),
+                    photo.getLocation().getY(),
+                    photo.getLocation().getX()
+            );
+        }
+    }
+
+}

--- a/src/main/java/kr/kro/photoliner/domain/photo/dto/response/ViewportResponse.java
+++ b/src/main/java/kr/kro/photoliner/domain/photo/dto/response/ViewportResponse.java
@@ -3,22 +3,22 @@ package kr.kro.photoliner.domain.photo.dto.response;
 import kr.kro.photoliner.common.util.datetime.DateTimes;
 import kr.kro.photoliner.domain.photo.model.Photo;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 public record ViewportResponse(
         PhotosResponse photos,
         List<InnerPointResponse> points
 ) {
-    public static ViewportResponse from(List<Photo> photos, LocalDateTime from, LocalDateTime to){
+    public static ViewportResponse from(List<Photo> photos, LocalDate from, LocalDate to){
         PhotosResponse photosResponse = PhotosResponse.from(
                 photos.stream()
-                        .filter(it-> DateTimes.isBetween(from, to, it.getCapturedDt()))
+                        .filter(it->isBetweenDate(from, to, it))
                         .toList()
         );
 
         List<InnerPointResponse> points = photos.stream()
-                .filter(it->DateTimes.isBetween(from, to, it.getCapturedDt()))
+                .filter(it->!isBetweenDate(from, to, it))
                 .map(InnerPointResponse::from)
                 .toList();
 
@@ -37,6 +37,10 @@ public record ViewportResponse(
                     photo.getLocation().getX()
             );
         }
+    }
+
+    private static boolean isBetweenDate(LocalDate from, LocalDate to, Photo photo){
+        return DateTimes.isBetween(from, to, photo.getCapturedDt().toLocalDate());
     }
 
 }

--- a/src/main/java/kr/kro/photoliner/domain/photo/model/Photo.java
+++ b/src/main/java/kr/kro/photoliner/domain/photo/model/Photo.java
@@ -12,6 +12,8 @@ import jakarta.persistence.JoinColumn;
 import kr.kro.photoliner.common.model.BaseEntity;
 import kr.kro.photoliner.domain.user.model.User;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import lombok.Setter;
 import org.locationtech.jts.geom.Point;
 
@@ -26,18 +28,23 @@ public class Photo extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NonNull
     @Column(name = "file_name", nullable = false)
     private String fileName;
 
+    @NonNull
     @Column(name = "file_path", nullable = false)
     private String filePath;
 
+    @NonNull
     @Column(name = "captured_dt", nullable = false)
     private LocalDateTime capturedDt;
 
+    @NonNull
     @Column(name = "location", nullable = false)
     private Point location;
 
+    @NonNull
     @MapsId
     @ManyToOne
     @JoinColumn(name = "user_id", referencedColumnName = "id")

--- a/src/main/java/kr/kro/photoliner/domain/photo/model/Photo.java
+++ b/src/main/java/kr/kro/photoliner/domain/photo/model/Photo.java
@@ -1,14 +1,6 @@
 package kr.kro.photoliner.domain.photo.model;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
-import jakarta.persistence.Id;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Column;
-import jakarta.persistence.MapsId;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.JoinColumn;
+import jakarta.persistence.*;
 import kr.kro.photoliner.common.model.BaseEntity;
 import kr.kro.photoliner.domain.user.model.User;
 import lombok.Getter;
@@ -44,9 +36,7 @@ public class Photo extends BaseEntity {
     @Column(name = "location", nullable = false)
     private Point location;
 
-    @NonNull
-    @MapsId
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", referencedColumnName = "id")
     private User user;
 }

--- a/src/main/java/kr/kro/photoliner/domain/photo/model/Photo.java
+++ b/src/main/java/kr/kro/photoliner/domain/photo/model/Photo.java
@@ -9,6 +9,7 @@ import lombok.NonNull;
 import lombok.Setter;
 import org.locationtech.jts.geom.Point;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity

--- a/src/main/java/kr/kro/photoliner/domain/photo/repository/PhotoRepository.java
+++ b/src/main/java/kr/kro/photoliner/domain/photo/repository/PhotoRepository.java
@@ -17,8 +17,8 @@ public interface PhotoRepository extends Repository<Photo, Long> {
 
     @Query("""
         select p
-        from photos p
-        where p.userId = :userId
+        from Photo p
+        where p.user.id = :userId
           and function('st_x', p.location) between function('st_x', :sw) and function('st_x', :ne)
           and function('st_y', p.location) between function('st_y', :sw) and function('st_y', :ne)
         order by p.capturedDt desc

--- a/src/main/java/kr/kro/photoliner/domain/photo/repository/PhotoRepository.java
+++ b/src/main/java/kr/kro/photoliner/domain/photo/repository/PhotoRepository.java
@@ -1,0 +1,31 @@
+package kr.kro.photoliner.domain.photo.repository;
+
+import kr.kro.photoliner.domain.photo.model.Photo;
+import org.locationtech.jts.geom.Point;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface PhotoRepository extends Repository<Photo, Long> {
+    List<Photo> findByUserId(
+            Long userId,
+            Pageable pageable
+    );
+
+    @Query("""
+        select p
+        from photos p
+        where p.userId = :userId
+          and function('st_x', p.location) between function('st_x', :sw) and function('st_x', :ne)
+          and function('st_y', p.location) between function('st_y', :sw) and function('st_y', :ne)
+        order by p.capturedDt desc
+        """)
+    List<Photo> findByUserIdInBox(
+            Long userId,
+            Point sw,
+            Point ne
+    );
+}

--- a/src/main/java/kr/kro/photoliner/domain/photo/service/PhotoService.java
+++ b/src/main/java/kr/kro/photoliner/domain/photo/service/PhotoService.java
@@ -20,8 +20,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PhotoService {
 
-    private PhotoRepository photoRepository;
-    private GeometryFactory geometryFactory;
+    private final PhotoRepository photoRepository;
+    private final GeometryFactory geometryFactory;
 
     public PhotosResponse getPhotoList(Long userId){
         Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());

--- a/src/main/java/kr/kro/photoliner/domain/photo/service/PhotoService.java
+++ b/src/main/java/kr/kro/photoliner/domain/photo/service/PhotoService.java
@@ -1,10 +1,47 @@
 package kr.kro.photoliner.domain.photo.service;
 
+import kr.kro.photoliner.domain.photo.dto.response.PhotosResponse;
+import kr.kro.photoliner.domain.photo.dto.response.ViewportResponse;
+import kr.kro.photoliner.domain.photo.model.Photo;
+import kr.kro.photoliner.domain.photo.repository.PhotoRepository;
 import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class PhotoService {
 
+    private PhotoRepository photoRepository;
+    private GeometryFactory geometryFactory;
+
+    public PhotosResponse getPhotoList(Long userId){
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+        List<Photo> photos = photoRepository.findByUserId(userId, pageable);
+        return PhotosResponse.from(photos);
+    }
+
+    public ViewportResponse getViewport(
+            Long userId,
+            LocalDateTime from,
+            LocalDateTime to,
+            double swLat,
+            double swLng,
+            double neLat,
+            double neLng
+    ){
+        Point sw = geometryFactory.createPoint(new Coordinate(swLng, swLat));
+        Point ne = geometryFactory.createPoint(new Coordinate(neLng, neLat));
+        List<Photo> photos = photoRepository.findByUserIdInBox(userId, sw, ne);
+
+        return ViewportResponse.from(photos, from, to);
+    }
 }

--- a/src/main/java/kr/kro/photoliner/domain/photo/service/PhotoService.java
+++ b/src/main/java/kr/kro/photoliner/domain/photo/service/PhotoService.java
@@ -13,7 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -31,8 +31,8 @@ public class PhotoService {
 
     public ViewportResponse getViewport(
             Long userId,
-            LocalDateTime from,
-            LocalDateTime to,
+            LocalDate from,
+            LocalDate to,
             double swLat,
             double swLng,
             double neLat,

--- a/src/main/java/kr/kro/photoliner/domain/user/model/User.java
+++ b/src/main/java/kr/kro/photoliner/domain/user/model/User.java
@@ -2,9 +2,13 @@ package kr.kro.photoliner.domain.user.model;
 
 import kr.kro.photoliner.common.model.BaseEntity;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.Setter;
 
 import jakarta.persistence.*;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "users")
@@ -20,4 +24,9 @@ public class User extends BaseEntity {
 
     @Column(name = "name", nullable = false)
     private String name;
+
+    @NonNull
+    @CreatedDate
+    @Column(name = "updated_at", columnDefinition = "TIMESTAMP", nullable = false, updatable = true)
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/kr/kro/photoliner/global/config/GeometryConfig.java
+++ b/src/main/java/kr/kro/photoliner/global/config/GeometryConfig.java
@@ -1,0 +1,14 @@
+package kr.kro.photoliner.global.config;
+
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GeometryConfig {
+    @Bean
+    public GeometryFactory geometryFactory(){
+        return new GeometryFactory(new PrecisionModel(), 4326); // 4326 : 글로벌 표준 지리좌표계 코드
+    }
+}

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,21 @@
+create table if not exists users
+(
+    id bigint unsigned auto_increment comment '사용자 고유 ID'
+        primary key,
+    username varchar(30) not null unique,
+    name varchar(30) not null ,
+    created_at datetime not null default current_timestamp,
+    updated_at datetime not null default current_timestamp
+);
+
+create table if not exists photos
+(
+    id bigint unsigned auto_increment comment '사진 고유 ID'
+        primary key,
+    file_name text not null,
+    file_path text not null,
+    captured_dt datetime not null,
+    location point not null,
+    user_id bigint not null,
+    created_at datetime not null default current_timestamp
+)


### PR DESCRIPTION
## 📄 개요
사진 목록을 조회하는 API 라우트와 비즈니스 로직 설계 

## 🛠️ 작업 내용
- 사진 목록 조회 API 추가
- 지도에 표시할 정보(사진 + 포인트) 데이터 조회 API 추가
- 마이그레이션 스크립트 추가
- 의존성 라이브러리 및 버전 수정 

### 🏷️사진 목록 조회 API
```
GET /api/v1/photo/list?userId={사용자ID}
```
- 특정 사용자의 사진 목록을 조회하는 API 

### 🏷️지도에 표시할 정보 데이터 조회 API 추가
```
GET /api/v1/photo/viewport?userId={사용자ID}&from={조회시작날짜}&to={조회마지막날짜}&swLat={좌하단위도}&swLng={좌하단경도}&neLat={우상단위도}&neLat={우상단경도}
```
- 위치/날짜 범위에 해당하는 사진 목록과 위치 범위에 해당하는 사진 위치 (포인트) 목록들을 조회하는 API

### 📄 마이그레이션 스크립트 추가
> 'V1__init.sql'
- users, photos 테이블을 추가하는 SQL 

### 📚 의존성 라이브러리 및 버전 수정
- 기존 
    - org.hibernate:hibernate-spatial:5.6.15.Final
- 변경 
    - org.hibernate.orm:hibernate-spatial:6.6.34.Final (변경)
    - org.locationtech.jts:jts-core:1.19.0 (추가)

- MySQL 라이브러리의 버전 충돌 문제로 버전 일치 및 jts-core 라이브러리 추가 

## 🎯 앞으로 해야할 것
- /list, /viewport API 에 검색 조건 추가 
- FrontEnd에서 ImageUrl 요청 시 처리 방식 고안 및 구현
