### PR TITLE
feat: 사진 앨범 도메인 추가

### DIFF
--- a/src/main/java/kr/kro/photoliner/domain/album/controller/AlbumController.java
+++ b/src/main/java/kr/kro/photoliner/domain/album/controller/AlbumController.java
@@ -1,0 +1,53 @@
+package kr.kro.photoliner.domain.album.controller;
+
+import jakarta.validation.Valid;
+import kr.kro.photoliner.domain.album.dto.request.AlbumCreateRequest;
+import kr.kro.photoliner.domain.album.dto.request.AlbumDeleteRequest;
+import kr.kro.photoliner.domain.album.dto.response.AlbumCreateResponse;
+import kr.kro.photoliner.domain.album.dto.response.AlbumsResponse;
+import kr.kro.photoliner.domain.album.service.AlbumService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/albums")
+public class AlbumController {
+
+    private final AlbumService albumService;
+
+    @PostMapping
+    public ResponseEntity<AlbumCreateResponse> createAlbum(
+            @Valid @RequestBody AlbumCreateRequest request
+    ) {
+        AlbumCreateResponse response = albumService.createAlbum(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<AlbumsResponse> getAlbums(
+            @RequestParam Long userId,
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(albumService.getAlbums(userId, pageable));
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deletePhoto(
+            @Valid @RequestBody AlbumDeleteRequest request
+    ) {
+        albumService.deleteAlbums(request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/kr/kro/photoliner/domain/album/dto/request/AlbumCreateRequest.java
+++ b/src/main/java/kr/kro/photoliner/domain/album/dto/request/AlbumCreateRequest.java
@@ -1,0 +1,12 @@
+package kr.kro.photoliner.domain.album.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+public record AlbumCreateRequest(
+        @NotNull
+        Long userId,
+        @NotEmpty
+        String name
+) {
+}

--- a/src/main/java/kr/kro/photoliner/domain/album/dto/request/AlbumDeleteRequest.java
+++ b/src/main/java/kr/kro/photoliner/domain/album/dto/request/AlbumDeleteRequest.java
@@ -1,0 +1,8 @@
+package kr.kro.photoliner.domain.album.dto.request;
+
+import java.util.List;
+
+public record AlbumDeleteRequest(
+        List<Long> ids
+) {
+}

--- a/src/main/java/kr/kro/photoliner/domain/album/dto/response/AlbumCreateResponse.java
+++ b/src/main/java/kr/kro/photoliner/domain/album/dto/response/AlbumCreateResponse.java
@@ -1,0 +1,24 @@
+package kr.kro.photoliner.domain.album.dto.response;
+
+import kr.kro.photoliner.domain.album.model.Album;
+
+public record AlbumCreateResponse(
+        InnerAlbum album
+) {
+
+    public static AlbumCreateResponse from(Album album) {
+        return new AlbumCreateResponse(
+                new InnerAlbum(
+                        album.getId(),
+                        album.getName()
+                )
+        );
+    }
+
+    public record InnerAlbum(
+            Long id,
+            String name
+    ) {
+
+    }
+}

--- a/src/main/java/kr/kro/photoliner/domain/album/dto/response/AlbumsResponse.java
+++ b/src/main/java/kr/kro/photoliner/domain/album/dto/response/AlbumsResponse.java
@@ -1,0 +1,54 @@
+package kr.kro.photoliner.domain.album.dto.response;
+
+import java.util.List;
+import kr.kro.photoliner.domain.album.model.Album;
+import org.springframework.data.domain.Page;
+
+public record AlbumsResponse(
+        List<InnerAlbum> albums,
+        InnerPageInfo pageInfo
+) {
+
+    public static AlbumsResponse from(Page<Album> albumPage) {
+        return new AlbumsResponse(
+                albumPage.getContent().stream()
+                        .map(InnerAlbum::from)
+                        .toList(),
+                InnerPageInfo.from(albumPage)
+        );
+    }
+
+    public record InnerAlbum(
+            Long id,
+            String name
+    ) {
+
+        public static InnerAlbum from(Album album) {
+            return new InnerAlbum(
+                    album.getId(),
+                    album.getName()
+            );
+        }
+    }
+
+    public record InnerPageInfo(
+            long totalElements,
+            int totalPages,
+            int currentPage,
+            int size,
+            boolean hasNext,
+            boolean hasPrevious
+    ) {
+
+        public static InnerPageInfo from(Page<Album> page) {
+            return new InnerPageInfo(
+                    page.getTotalElements(),
+                    page.getTotalPages(),
+                    page.getNumber(),
+                    page.getSize(),
+                    page.hasNext(),
+                    page.hasPrevious()
+            );
+        }
+    }
+}

--- a/src/main/java/kr/kro/photoliner/domain/album/model/Album.java
+++ b/src/main/java/kr/kro/photoliner/domain/album/model/Album.java
@@ -1,0 +1,40 @@
+package kr.kro.photoliner.domain.album.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import kr.kro.photoliner.common.model.BaseEntity;
+import kr.kro.photoliner.domain.user.model.User;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "albums")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class Album extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", referencedColumnName = "id")
+    private User user;
+}

--- a/src/main/java/kr/kro/photoliner/domain/album/model/Albums.java
+++ b/src/main/java/kr/kro/photoliner/domain/album/model/Albums.java
@@ -1,0 +1,12 @@
+package kr.kro.photoliner.domain.album.model;
+
+import java.util.List;
+
+public record Albums(
+        List<Album> albums
+) {
+
+    public int count() {
+        return albums.size();
+    }
+}

--- a/src/main/java/kr/kro/photoliner/domain/album/repository/AlbumRepository.java
+++ b/src/main/java/kr/kro/photoliner/domain/album/repository/AlbumRepository.java
@@ -1,0 +1,13 @@
+package kr.kro.photoliner.domain.album.repository;
+
+import kr.kro.photoliner.domain.album.model.Album;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AlbumRepository extends JpaRepository<Album, Long> {
+
+    Album save(Album album);
+
+    Page<Album> findByUserId(Long userId, Pageable pageable);
+}

--- a/src/main/java/kr/kro/photoliner/domain/album/service/AlbumService.java
+++ b/src/main/java/kr/kro/photoliner/domain/album/service/AlbumService.java
@@ -1,0 +1,48 @@
+package kr.kro.photoliner.domain.album.service;
+
+import kr.kro.photoliner.domain.album.dto.request.AlbumCreateRequest;
+import kr.kro.photoliner.domain.album.dto.request.AlbumDeleteRequest;
+import kr.kro.photoliner.domain.album.dto.response.AlbumCreateResponse;
+import kr.kro.photoliner.domain.album.dto.response.AlbumsResponse;
+import kr.kro.photoliner.domain.album.model.Album;
+import kr.kro.photoliner.domain.album.repository.AlbumRepository;
+import kr.kro.photoliner.domain.user.model.User;
+import kr.kro.photoliner.domain.user.repository.UserRepository;
+import kr.kro.photoliner.global.code.ApiResponseCode;
+import kr.kro.photoliner.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AlbumService {
+
+    private final UserRepository userRepository;
+    private final AlbumRepository albumRepository;
+
+    @Transactional
+    public AlbumCreateResponse createAlbum(AlbumCreateRequest request) {
+        User user = userRepository.findUserById(request.userId())
+                .orElseThrow(() -> CustomException.of(ApiResponseCode.NOT_FOUND_USER, "user id: " + request.userId()));
+        Album album = Album.builder()
+                .name(request.name())
+                .user(user)
+                .build();
+        Album savedAlbum = albumRepository.save(album);
+        return AlbumCreateResponse.from(savedAlbum);
+    }
+
+    @Transactional(readOnly = true)
+    public AlbumsResponse getAlbums(Long userId, Pageable pageable) {
+        Page<Album> albums = albumRepository.findByUserId(userId, pageable);
+        return AlbumsResponse.from(albums);
+    }
+
+    @Transactional
+    public void deleteAlbums(AlbumDeleteRequest request) {
+        albumRepository.deleteAllByIdInBatch(request.ids());
+    }
+}

--- a/src/main/java/kr/kro/photoliner/domain/photo/controller/PhotoController.java
+++ b/src/main/java/kr/kro/photoliner/domain/photo/controller/PhotoController.java
@@ -39,11 +39,20 @@ public class PhotoController {
     private final PhotoUploadService photoUploadService;
 
     @GetMapping
-    public ResponseEntity<PhotosResponse> getPhotoList(
+    public ResponseEntity<PhotosResponse> getPhotos(
             @RequestParam Long userId,
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        return ResponseEntity.ok(photoService.getPhotoList(userId, pageable));
+        return ResponseEntity.ok(photoService.getPhotos(userId, pageable));
+    }
+
+    @GetMapping("/albums/{albumId}")
+    public ResponseEntity<PhotosResponse> getPhotosByAlbumId(
+            @PathVariable Long albumId,
+            @RequestParam Long userId,
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(photoService.getPhotosByAlbumId(userId, albumId, pageable));
     }
 
     @GetMapping("/markers")

--- a/src/main/java/kr/kro/photoliner/domain/photo/dto/request/MapMarkersRequest.java
+++ b/src/main/java/kr/kro/photoliner/domain/photo/dto/request/MapMarkersRequest.java
@@ -3,19 +3,14 @@ package kr.kro.photoliner.domain.photo.dto.request;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
-import java.time.LocalDate;
 import org.locationtech.jts.geom.Coordinate;
-import org.springframework.format.annotation.DateTimeFormat;
 
 public record MapMarkersRequest(
         @NotNull @Min(0)
         Long userId,
 
-        @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-        LocalDate from,
-
-        @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-        LocalDate to,
+        @NotNull @Min(0)
+        Long albumId,
 
         @Min(0) @Max(90)
         double swLat,

--- a/src/main/java/kr/kro/photoliner/domain/photo/model/AlbumPhoto.java
+++ b/src/main/java/kr/kro/photoliner/domain/photo/model/AlbumPhoto.java
@@ -1,0 +1,39 @@
+package kr.kro.photoliner.domain.photo.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.Objects;
+import kr.kro.photoliner.domain.album.model.Album;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@Table(name = "albums_photos")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AlbumPhoto {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "album_id", nullable = false)
+    private Album album;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "photo_id", nullable = false)
+    private Photo photo;
+
+    public boolean isIncludedInAlbum(Long albumId) {
+        return Objects.equals(album.getId(), albumId);
+    }
+}

--- a/src/main/java/kr/kro/photoliner/domain/photo/model/AlbumPhotos.java
+++ b/src/main/java/kr/kro/photoliner/domain/photo/model/AlbumPhotos.java
@@ -1,0 +1,22 @@
+package kr.kro.photoliner.domain.photo.model;
+
+import java.util.List;
+
+public record AlbumPhotos(
+        List<AlbumPhoto> albumPhotos
+) {
+    public List<Photo> getPhotoIncludedAlbum(Long albumId) {
+        return albumPhotos.stream()
+                .filter(albumPhoto -> albumPhoto.isIncludedInAlbum(albumId))
+                .map(AlbumPhoto::getPhoto)
+                .toList();
+    }
+
+    public List<Photo> getPhotoNotIncludedAlbum(Long albumId) {
+        return albumPhotos.stream()
+                .filter(albumPhoto -> albumPhoto.isIncludedInAlbum(albumId))
+                .map(AlbumPhoto::getPhoto)
+                .toList();
+    }
+
+}

--- a/src/main/java/kr/kro/photoliner/domain/photo/model/Photos.java
+++ b/src/main/java/kr/kro/photoliner/domain/photo/model/Photos.java
@@ -1,6 +1,5 @@
 package kr.kro.photoliner.domain.photo.model;
 
-import java.time.LocalDate;
 import java.util.List;
 
 public record Photos(
@@ -11,15 +10,9 @@ public record Photos(
         return photos.size();
     }
 
-    public List<Photo> filterInDate(LocalDate from, LocalDate to) {
+    public List<Long> getPhotoIds() {
         return photos.stream()
-                .filter(photo -> photo.isBetween(from, to))
-                .toList();
-    }
-
-    public List<Photo> filterOutOfDate(LocalDate from, LocalDate to) {
-        return photos.stream()
-                .filter(photo -> !photo.isBetween(from, to))
+                .map(Photo::getId)
                 .toList();
     }
 }

--- a/src/main/java/kr/kro/photoliner/domain/photo/repository/AlbumPhotoRepository.java
+++ b/src/main/java/kr/kro/photoliner/domain/photo/repository/AlbumPhotoRepository.java
@@ -1,0 +1,17 @@
+package kr.kro.photoliner.domain.photo.repository;
+
+import java.util.List;
+import kr.kro.photoliner.domain.photo.model.AlbumPhoto;
+import kr.kro.photoliner.domain.photo.model.AlbumPhotos;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AlbumPhotoRepository extends JpaRepository<AlbumPhoto, Long> {
+
+    List<AlbumPhoto> findByPhotoIdIn(List<Long> ids);
+
+    default AlbumPhotos getByPhotoIdIn(List<Long> ids) {
+        return new AlbumPhotos(
+                findByPhotoIdIn(ids)
+        );
+    }
+}

--- a/src/main/java/kr/kro/photoliner/domain/photo/repository/PhotoRepository.java
+++ b/src/main/java/kr/kro/photoliner/domain/photo/repository/PhotoRepository.java
@@ -18,6 +18,14 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
     );
 
     @Query("""
+                select p
+                from Photo p
+                inner join AlbumPhoto ap on ap.photo.id = p.id
+                where ap.album.id = :albumId
+            """)
+    Page<Photo> findByUserIdAndAlbumId(Long userId, Long albumId, Pageable pageable);
+
+    @Query("""
             select p
             from Photo p
             where p.user.id = :userId

--- a/src/main/java/kr/kro/photoliner/domain/photo/service/PhotoService.java
+++ b/src/main/java/kr/kro/photoliner/domain/photo/service/PhotoService.java
@@ -6,8 +6,10 @@ import kr.kro.photoliner.domain.photo.dto.request.PhotoCapturedDateUpdateRequest
 import kr.kro.photoliner.domain.photo.dto.request.PhotoLocationUpdateRequest;
 import kr.kro.photoliner.domain.photo.dto.response.MapMarkersResponse;
 import kr.kro.photoliner.domain.photo.dto.response.PhotosResponse;
+import kr.kro.photoliner.domain.photo.model.AlbumPhotos;
 import kr.kro.photoliner.domain.photo.model.Photo;
 import kr.kro.photoliner.domain.photo.model.Photos;
+import kr.kro.photoliner.domain.photo.repository.AlbumPhotoRepository;
 import kr.kro.photoliner.domain.photo.repository.PhotoRepository;
 import kr.kro.photoliner.global.code.ApiResponseCode;
 import kr.kro.photoliner.global.exception.CustomException;
@@ -23,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PhotoService {
 
+    private final AlbumPhotoRepository albumPhotoRepository;
     private final PhotoRepository photoRepository;
     private final GeometryFactory geometryFactory;
 
@@ -37,10 +40,11 @@ public class PhotoService {
         Point ne = geometryFactory.createPoint(request.getNorthEastCoordinate());
 
         Photos photos = photoRepository.getPhotosByUserIdInBox(request.userId(), sw, ne);
+        AlbumPhotos albumPhotos = albumPhotoRepository.getByPhotoIdIn(photos.getPhotoIds());
 
         return MapMarkersResponse.of(
-                photos.filterInDate(request.from(), request.to()),
-                photos.filterOutOfDate(request.from(), request.to())
+                albumPhotos.getPhotoIncludedAlbum(request.albumId()),
+                albumPhotos.getPhotoNotIncludedAlbum(request.albumId())
         );
     }
 

--- a/src/main/java/kr/kro/photoliner/domain/photo/service/PhotoService.java
+++ b/src/main/java/kr/kro/photoliner/domain/photo/service/PhotoService.java
@@ -30,8 +30,13 @@ public class PhotoService {
     private final GeometryFactory geometryFactory;
 
     @Transactional(readOnly = true)
-    public PhotosResponse getPhotoList(Long userId, Pageable pageable) {
+    public PhotosResponse getPhotos(Long userId, Pageable pageable) {
         return PhotosResponse.from(photoRepository.findByUserId(userId, pageable));
+    }
+
+    @Transactional(readOnly = true)
+    public PhotosResponse getPhotosByAlbumId(Long userId, Long albumId, Pageable pageable) {
+        return PhotosResponse.from(photoRepository.findByUserIdAndAlbumId(userId, albumId, pageable));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/kr/kro/photoliner/domain/photo/service/PhotoUploadService.java
+++ b/src/main/java/kr/kro/photoliner/domain/photo/service/PhotoUploadService.java
@@ -37,7 +37,6 @@ public class PhotoUploadService {
                             .orElseThrow(
                                     () -> CustomException.of(ApiResponseCode.NOT_FOUND_USER, "user id: " + userId));
                     Photo photo = createPhoto(user, exifData, filePath, fileName);
-                            .orElseThrow(RuntimeException::new);
                     Photo savedPhoto = photoRepository.save(photo);
                     return InnerUploadedPhotoInfo.from(savedPhoto);
                 })

--- a/src/main/resources/db/migration/V4__add_albums_table.sql
+++ b/src/main/resources/db/migration/V4__add_albums_table.sql
@@ -10,8 +10,8 @@ create table if not exists albums
 
 create table if not exists albums_photos
 (
+    id       bigint unsigned auto_increment
+        primary key,
     album_id bigint,
-    photo_id bigint,
-    constraint pk_albums_photos
-        primary key (album_id, photo_id)
+    photo_id bigint
 )

--- a/src/main/resources/db/migration/V4__add_albums_table.sql
+++ b/src/main/resources/db/migration/V4__add_albums_table.sql
@@ -1,0 +1,15 @@
+create table if not exists albums
+(
+    id         bigint unsigned auto_increment comment '앨범 고유 ID'
+        primary key,
+    name       varchar(20) not null,
+    created_at datetime    not null default current_timestamp,
+    updated_at datetime    not null default current_timestamp,
+    user_id    bigint      not null
+);
+
+create table if not exists albums_photos
+(
+    album_id bigint primary key,
+    photo_id bigint primary key
+)

--- a/src/main/resources/db/migration/V4__add_albums_table.sql
+++ b/src/main/resources/db/migration/V4__add_albums_table.sql
@@ -10,6 +10,8 @@ create table if not exists albums
 
 create table if not exists albums_photos
 (
-    album_id bigint primary key,
-    photo_id bigint primary key
+    album_id bigint,
+    photo_id bigint,
+    constraint pk_albums_photos
+        primary key (album_id, photo_id)
 )


### PR DESCRIPTION
## 📌 ISSUE 번호
- close #36 

## 📄 작업 내용 요약
- 앨범 도메인 추가 
- 앨범 CRUD 추가
- 지도 사진 조회 API 검색 조건 변경 
- 앨범 기준 사진 조회 API 추가

### 🏗️  앨범 테이블 설계
<img width="795" height="518" alt="image" src="https://github.com/user-attachments/assets/84e2c75a-5a8b-41ac-8855-a0b53351eb11" />
- 앨범 테이블 추가
- 앨범 내 저장된 사진 데이터를 의미하는 앨범-사진 관계 테이블 추가

#### 📦  앨범-사진 관계 도메인
- 앨범-사진 관계 테이블에 대한 별도의 도메인 클래스 `AlbumPhoto` 정의 

### 🕹️  앨범 CRUD 추가

### 🔍  지도 사진 조회 API 검색 조건 변경 
- 검색 조건 변경
    - 이전 : 시작 날짜(`from`)와 끝 날짜(`to`) 범위 내의 사진을 `PhotoMarker`로 변환
    - 변경 : 클라이언트로부터 요청받은 `albumId`에 해당하는 사진을 `PhotoMarker`로 변환 


## 📢 참고 사항


## ✅ 체크리스트
- [X] ISSUE 번호 연결 했나요?
- [X] Reviewers 지정 했나요?
- [X] Assignees 지정 했나요?
- [X] Labels 지정 했나요?
